### PR TITLE
CCL-3005: Update ECR TF module, make prefix optional, add suffix option

### DIFF
--- a/.github/workflows/pull-request-sast.yaml
+++ b/.github/workflows/pull-request-sast.yaml
@@ -20,7 +20,7 @@ jobs:
 
       # Results have to be a table as the organisation does not have Advanced Security license.
       - name: Terraform Trivy Scan
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           scan-type: 'config'
          #trivyignores: ".trivyignore"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ Lambda ARNS must be declared in a separate list that can only be defined at a pe
 
 ecr_prefix must be provided. This is to provide some logical separation of ECR repositories. This should typically be the name of the tenant or team.
 
+# ECR Repository Name
+To avoid compatibility issues with ArgoCD not supporting ECR "Namespaces" e.g. `/ (team1/nginx)` we will be disallowing the use of forward slashes. This module will convert these to hyphens.
+
+This is due to the way ArgoCD handles ECR credentials for HELM and this might be re-visited when it's resolved. For now we will only be creating "flat" ECR repositories
+
+Also, prefixes, suffixes and ecr repo names cannot begin or end with hyphens '-'. These will be trimmed off
+
 ## Expected YAML config with Explanations
 ```
 common_options: # These are common options that can be re-used by all of your ECR repositories
@@ -81,7 +88,7 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | terraform-aws-modules/ecr/aws | 2.3.1 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | terraform-aws-modules/ecr/aws | 2.4.0 |
 
 ## Resources
 
@@ -92,7 +99,8 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ecr_config"></a> [ecr\_config](#input\_ecr\_config) | Path to YAML file that contains ECR repositories | `any` | n/a | yes |
-| <a name="input_ecr_prefix"></a> [ecr\_prefix](#input\_ecr\_prefix) | This is used to provide logical separation of ECR repositories. This will most likely be the name of the tenant or team | `string` | n/a | yes |
+| <a name="input_ecr_prefix"></a> [ecr\_prefix](#input\_ecr\_prefix) | This is used to provide logical separation of ECR repositories. This will most likely be the name of the tenant or team | `string` | `null` | no |
+| <a name="input_ecr_suffix"></a> [ecr\_suffix](#input\_ecr\_suffix) | This can be optionally used to help to quickly identify what a given ECR repository is used for. E.g. helm (example-helm) | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,13 @@
 variable "ecr_prefix" {
   type        = string
   description = "This is used to provide logical separation of ECR repositories. This will most likely be the name of the tenant or team"
+  default     = null
+}
+
+variable "ecr_suffix" {
+  type        = string
+  description = "This can be optionally used to help to quickly identify what a given ECR repository is used for. E.g. helm (example-helm)"
+  default     = null
 }
 
 variable "ecr_config" {


### PR DESCRIPTION
Other changes:
- Disallow use of ECR namespaces (repos with forward slash)
- Bump TF Module Version to 2.4.0
- Bump trivy version